### PR TITLE
Fix dark square award calculation and add two new fun stats

### DIFF
--- a/app/stats/round/[roundNumber]/page.tsx
+++ b/app/stats/round/[roundNumber]/page.tsx
@@ -327,6 +327,20 @@ interface StatsData {
       white: string
       black: string
     } | null
+    lightLord: {
+      captures: number
+      gameIndex: number
+      color: string
+      white: string
+      black: string
+    } | null
+    parkourMaster: {
+      knightMoves: number
+      gameIndex: number
+      color: string
+      white: string
+      black: string
+    } | null
     chickenAward: {
       retreats: number
       gameIndex: number

--- a/components/stats/fun-stats.tsx
+++ b/components/stats/fun-stats.tsx
@@ -120,6 +120,20 @@ interface FunStatsProps {
       white: string
       black: string
     } | null
+    lightLord: {
+      captures: number
+      gameIndex: number
+      color: string
+      white: string
+      black: string
+    } | null
+    parkourMaster: {
+      knightMoves: number
+      gameIndex: number
+      color: string
+      white: string
+      black: string
+    } | null
     chickenAward: {
       retreats: number
       gameIndex: number
@@ -394,6 +408,30 @@ export function FunStats({ funStats }: FunStatsProps) {
             </div>
             <div className="text-xs text-gray-300 dark:text-gray-400 mt-1">
               {funStats.darkLord.color} captured {funStats.darkLord.captures} pieces on dark squares
+            </div>
+          </div>
+        )}
+
+        {funStats.lightLord && (
+          <div className="p-4 bg-yellow-100 dark:bg-yellow-900/20 rounded-lg border border-yellow-300 dark:border-yellow-700">
+            <div className="font-semibold text-yellow-900 dark:text-yellow-300 mb-1">☀️ Light Brigade</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerVs white={funStats.lightLord.white} black={funStats.lightLord.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              {funStats.lightLord.color} captured {funStats.lightLord.captures} pieces on light squares
+            </div>
+          </div>
+        )}
+
+        {funStats.parkourMaster && (
+          <div className="p-4 bg-green-50 dark:bg-green-900/20 rounded-lg">
+            <div className="font-semibold text-green-900 dark:text-green-300 mb-1">🤸 Parkour Master</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerVs white={funStats.parkourMaster.white} black={funStats.parkourMaster.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              {funStats.parkourMaster.color} made {funStats.parkourMaster.knightMoves} knight {funStats.parkourMaster.knightMoves === 1 ? 'move' : 'moves'}
             </div>
           </div>
         )}

--- a/scripts/utils/calculators/fun-stats/index.js
+++ b/scripts/utils/calculators/fun-stats/index.js
@@ -19,6 +19,8 @@ const { calculateEdgeLord } = require('./edge-lord');
 const { calculateRookLift } = require('./rook-lift');
 const { calculateCenterStage } = require('./center-stage');
 const { calculateDarkLord } = require('./dark-lord');
+const { calculateLightLord } = require('./light-lord');
+const { calculateParkourMaster } = require('./parkour-master');
 const { calculateChickenAward } = require('./chicken-award');
 const { calculateSlowestCastling } = require('./slowest-castling');
 const { calculatePawnCaptures } = require('./pawn-captures');
@@ -55,6 +57,8 @@ function calculateFunStats(games, tacticalPatterns = null) {
     rookLift: calculateRookLift(gamesWithMoves),
     centerStage: calculateCenterStage(gamesWithMoves),
     darkLord: calculateDarkLord(gamesWithMoves),
+    lightLord: calculateLightLord(gamesWithMoves),
+    parkourMaster: calculateParkourMaster(gamesWithMoves),
     chickenAward: calculateChickenAward(gamesWithMoves),
     pawnCaptures: calculatePawnCaptures(gamesWithMoves),
     antiOrthogonal: calculateAntiOrthogonal(gamesWithMoves),

--- a/scripts/utils/calculators/fun-stats/light-lord.js
+++ b/scripts/utils/calculators/fun-stats/light-lord.js
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/**
+ * Light Lord (Light Brigade) Fun Stat
+ *
+ * Tracks the player with the most captures on light squares.
+ * A play on "Charge of the Light Brigade" - charging into battle on the bright squares.
+ */
+
+const { getPlayerNames, isLightSquare } = require('../helpers');
+
+/**
+ * Calculate light lord (most light square captures)
+ * @param {Array} games - Array of parsed game objects
+ * @returns {Object} Light lord stat
+ */
+function calculateLightLord(games) {
+  let lightLord = { captures: 0, gameIndex: null, color: null };
+
+  games.forEach((game, idx) => {
+    let whiteLightCaptures = 0;
+    let blackLightCaptures = 0;
+
+    game.moveList.forEach((move) => {
+      // Track light square captures
+      if (move.captured && isLightSquare(move.to)) {
+        if (move.color === 'w') {
+          whiteLightCaptures++;
+        } else {
+          blackLightCaptures++;
+        }
+      }
+    });
+
+    // Check if this game has the most light square captures
+    const players = getPlayerNames(game);
+    if (whiteLightCaptures > lightLord.captures) {
+      lightLord = {
+        captures: whiteLightCaptures,
+        gameIndex: idx,
+        color: 'White',
+        white: players.white,
+        black: players.black
+      };
+    }
+
+    if (blackLightCaptures > lightLord.captures) {
+      lightLord = {
+        captures: blackLightCaptures,
+        gameIndex: idx,
+        color: 'Black',
+        white: players.white,
+        black: players.black
+      };
+    }
+  });
+
+  return lightLord.captures > 0 ? lightLord : null;
+}
+
+module.exports = { calculateLightLord };

--- a/scripts/utils/calculators/fun-stats/parkour-master.js
+++ b/scripts/utils/calculators/fun-stats/parkour-master.js
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/**
+ * Parkour Master Fun Stat
+ *
+ * Tracks the player with the most knight moves in a single game.
+ * Named "Parkour Master" because knights jump over pieces like parkour athletes!
+ */
+
+const { getPlayerNames } = require('../helpers');
+
+/**
+ * Calculate parkour master (most knight moves in a game)
+ * @param {Array} games - Array of parsed game objects
+ * @returns {Object} Parkour master stat
+ */
+function calculateParkourMaster(games) {
+  let parkourMaster = { knightMoves: 0, gameIndex: null, color: null };
+
+  games.forEach((game, idx) => {
+    let whiteKnightMoves = 0;
+    let blackKnightMoves = 0;
+
+    game.moveList.forEach((move) => {
+      // Track knight moves (piece type is 'n' for knight)
+      if (move.piece === 'n') {
+        if (move.color === 'w') {
+          whiteKnightMoves++;
+        } else {
+          blackKnightMoves++;
+        }
+      }
+    });
+
+    // Check if this game has the most knight moves
+    const players = getPlayerNames(game);
+    if (whiteKnightMoves > parkourMaster.knightMoves) {
+      parkourMaster = {
+        knightMoves: whiteKnightMoves,
+        gameIndex: idx,
+        color: 'White',
+        white: players.white,
+        black: players.black
+      };
+    }
+
+    if (blackKnightMoves > parkourMaster.knightMoves) {
+      parkourMaster = {
+        knightMoves: blackKnightMoves,
+        gameIndex: idx,
+        color: 'Black',
+        white: players.white,
+        black: players.black
+      };
+    }
+  });
+
+  return parkourMaster.knightMoves > 0 ? parkourMaster : null;
+}
+
+module.exports = { calculateParkourMaster };

--- a/scripts/utils/calculators/helpers.js
+++ b/scripts/utils/calculators/helpers.js
@@ -38,7 +38,18 @@ function calculateDistance(from, to) {
 function isDarkSquare(square) {
   const file = square.charCodeAt(0) - 'a'.charCodeAt(0); // 0-7
   const rank = parseInt(square[1]) - 1; // 0-7
-  return (file + rank) % 2 === 1; // Dark squares have odd sum
+  return (file + rank) % 2 === 0; // Dark squares have even sum (a1, d4, e5, etc.)
+}
+
+/**
+ * Check if a square is a light square
+ * @param {string} square - Square notation (e.g., 'e4')
+ * @returns {boolean} True if light square
+ */
+function isLightSquare(square) {
+  const file = square.charCodeAt(0) - 'a'.charCodeAt(0); // 0-7
+  const rank = parseInt(square[1]) - 1; // 0-7
+  return (file + rank) % 2 === 1; // Light squares have odd sum
 }
 
 /**
@@ -107,6 +118,7 @@ module.exports = {
   filterGamesWithMoves,
   calculateDistance,
   isDarkSquare,
+  isLightSquare,
   getPlayerName,
   getPlayerNames,
   toFullMoves,


### PR DESCRIPTION
Fixed:
- isDarkSquare() helper was incorrectly using odd sum (% 2 === 1)
  instead of even sum (% 2 === 0) for dark squares
- Dark Mode Enthusiast award now correctly counts captures on
  dark squares like d4, e5, b2, etc.

Added:
- Light Brigade award: most captures on light squares
- Parkour Master award: most knight moves in a single game
- Both awards include TypeScript interfaces and UI components