### PR TITLE
Add missing fun stat awards to Hall of Fame

### DIFF
--- a/app/stats/overview/types.ts
+++ b/app/stats/overview/types.ts
@@ -50,6 +50,18 @@ export interface HallOfFame {
   mostObscureOpening: OpeningSuperlative | null
   biggestComeback: ComebackSuperlative | null
   luckyEscape: EscapeSuperlative | null
+  parkourMaster: ColorMetricSuperlative | null
+  pawnCaptures: ColorMetricSuperlative | null
+  dadbodShuffler: ColorMetricSuperlative | null
+  darkLord: ColorMetricSuperlative | null
+  lightLord: ColorMetricSuperlative | null
+  squareTourist: TouristSuperlative | null
+  pieceLoyalty: LoyaltySuperlative | null
+  slowestCastling: SimpleCastlingSuperlative | null
+  fastestQueenTrade: QueenTradeSuperlative | null
+  slowestQueenTrade: QueenTradeSuperlative | null
+  edgeLord: ColorMetricSuperlative | null
+  pawnStorm: PawnStormSuperlative | null
 }
 
 export interface GameSuperlative {
@@ -297,4 +309,63 @@ export interface AwardFrequencyEntry {
   displayName: string
   appearances: number
   percentage: number
+}
+
+// Additional Hall of Fame superlative types
+
+export interface ColorMetricSuperlative {
+  round: number
+  knightMoves?: number  // For parkourMaster
+  captures?: number      // For pawnCaptures, darkLord, lightLord
+  moves?: number         // For dadbodShuffler, edgeLord
+  color: string
+  white: string
+  black: string
+  gameIndex: number
+}
+
+export interface TouristSuperlative {
+  round: number
+  squares: number
+  piece: string
+  startSquare: string
+  color: string
+  white: string
+  black: string
+  gameIndex: number
+}
+
+export interface LoyaltySuperlative {
+  round: number
+  moves: number
+  piece: string
+  square: string
+  white: string
+  black: string
+  gameIndex: number
+}
+
+export interface SimpleCastlingSuperlative {
+  round: number
+  moves: number
+  color: string
+  white: string
+  black: string
+  gameIndex: number
+}
+
+export interface QueenTradeSuperlative {
+  round: number
+  moves: number
+  white: string
+  black: string
+  gameIndex: number
+}
+
+export interface PawnStormSuperlative {
+  round: number
+  count: number
+  white: string
+  black: string
+  gameIndex: number
 }

--- a/components/stats/overview/hall-of-fame-section.tsx
+++ b/components/stats/overview/hall-of-fame-section.tsx
@@ -180,6 +180,162 @@ export function HallOfFameSection({ hallOfFame }: HallOfFameSectionProps) {
           </div>
         )}
 
+        {/* Parkour Master */}
+        {hallOfFame.parkourMaster && (
+          <div className="p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-700">
+            <div className="font-semibold text-green-900 dark:text-green-300 mb-1">🤸 Ultimate Parkour Master</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerName name={hallOfFame.parkourMaster.color === 'White' ? hallOfFame.parkourMaster.white : hallOfFame.parkourMaster.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.parkourMaster.round} • {hallOfFame.parkourMaster.knightMoves} knight {hallOfFame.parkourMaster.knightMoves === 1 ? 'move' : 'moves'}
+            </div>
+          </div>
+        )}
+
+        {/* Pawn Captures */}
+        {hallOfFame.pawnCaptures && (
+          <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-lg border border-red-200 dark:border-red-700">
+            <div className="font-semibold text-red-900 dark:text-red-300 mb-1">🏴 Ultimate Peasant Uprising</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerName name={hallOfFame.pawnCaptures.color === 'White' ? hallOfFame.pawnCaptures.white : hallOfFame.pawnCaptures.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.pawnCaptures.round} • Pawns captured {hallOfFame.pawnCaptures.captures} {hallOfFame.pawnCaptures.captures === 1 ? 'piece' : 'pieces'}
+            </div>
+          </div>
+        )}
+
+        {/* Dadbod Shuffler */}
+        {hallOfFame.dadbodShuffler && (
+          <div className="p-4 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg border border-yellow-200 dark:border-yellow-700">
+            <div className="font-semibold text-yellow-900 dark:text-yellow-300 mb-1">👑 Ultimate Dadbod Shuffler</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerName name={hallOfFame.dadbodShuffler.color === 'White' ? hallOfFame.dadbodShuffler.white : hallOfFame.dadbodShuffler.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.dadbodShuffler.round} • King moved {hallOfFame.dadbodShuffler.moves} times
+            </div>
+          </div>
+        )}
+
+        {/* Dark Lord */}
+        {hallOfFame.darkLord && (
+          <div className="p-4 bg-gray-800 dark:bg-gray-950 rounded-lg border border-gray-700 dark:border-gray-800">
+            <div className="font-semibold text-gray-100 dark:text-gray-200 mb-1">🌑 Ultimate Dark Mode Enthusiast</div>
+            <div className="text-sm text-gray-200 dark:text-gray-300">
+              <PlayerName name={hallOfFame.darkLord.color === 'White' ? hallOfFame.darkLord.white : hallOfFame.darkLord.black} />
+            </div>
+            <div className="text-xs text-gray-300 dark:text-gray-400 mt-1">
+              Round {hallOfFame.darkLord.round} • Captured {hallOfFame.darkLord.captures} pieces on dark squares
+            </div>
+          </div>
+        )}
+
+        {/* Light Lord */}
+        {hallOfFame.lightLord && (
+          <div className="p-4 bg-yellow-100 dark:bg-yellow-900/20 rounded-lg border border-yellow-300 dark:border-yellow-700">
+            <div className="font-semibold text-yellow-900 dark:text-yellow-300 mb-1">☀️ Ultimate Light Brigade</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerName name={hallOfFame.lightLord.color === 'White' ? hallOfFame.lightLord.white : hallOfFame.lightLord.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.lightLord.round} • Captured {hallOfFame.lightLord.captures} pieces on light squares
+            </div>
+          </div>
+        )}
+
+        {/* Square Tourist */}
+        {hallOfFame.squareTourist && (
+          <div className="p-4 bg-teal-50 dark:bg-teal-900/20 rounded-lg border border-teal-200 dark:border-teal-700">
+            <div className="font-semibold text-teal-900 dark:text-teal-300 mb-1">✈️ Ultimate Square Tourist</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerName name={hallOfFame.squareTourist.color === 'White' ? hallOfFame.squareTourist.white : hallOfFame.squareTourist.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.squareTourist.round} • {hallOfFame.squareTourist.startSquare} {hallOfFame.squareTourist.piece} visited {hallOfFame.squareTourist.squares} different squares
+            </div>
+          </div>
+        )}
+
+        {/* Piece Loyalty */}
+        {hallOfFame.pieceLoyalty && (
+          <div className="p-4 bg-indigo-50 dark:bg-indigo-900/20 rounded-lg border border-indigo-200 dark:border-indigo-700">
+            <div className="font-semibold text-indigo-900 dark:text-indigo-300 mb-1">🏠 Ultimate Piece Loyalty</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerVs white={hallOfFame.pieceLoyalty.white} black={hallOfFame.pieceLoyalty.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.pieceLoyalty.round} • {hallOfFame.pieceLoyalty.piece} stayed on {hallOfFame.pieceLoyalty.square} for {hallOfFame.pieceLoyalty.moves} moves
+            </div>
+          </div>
+        )}
+
+        {/* Slowest Castling */}
+        {hallOfFame.slowestCastling && (
+          <div className="p-4 bg-slate-50 dark:bg-slate-900/20 rounded-lg border border-slate-200 dark:border-slate-700">
+            <div className="font-semibold text-slate-900 dark:text-slate-300 mb-1">🏰 Ultimate Castle Commitment Issues</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerName name={hallOfFame.slowestCastling.color === 'White' ? hallOfFame.slowestCastling.white : hallOfFame.slowestCastling.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.slowestCastling.round} • Castled on move {hallOfFame.slowestCastling.moves}
+            </div>
+          </div>
+        )}
+
+        {/* Fastest Queen Trade */}
+        {hallOfFame.fastestQueenTrade && (
+          <div className="p-4 bg-slate-50 dark:bg-slate-900/20 rounded-lg border border-slate-200 dark:border-slate-700">
+            <div className="font-semibold text-slate-900 dark:text-slate-300 mb-1">💼 Ultimate Strategic Downsizing</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerVs white={hallOfFame.fastestQueenTrade.white} black={hallOfFame.fastestQueenTrade.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.fastestQueenTrade.round} • Queens traded by move {hallOfFame.fastestQueenTrade.moves}
+            </div>
+          </div>
+        )}
+
+        {/* Slowest Queen Trade */}
+        {hallOfFame.slowestQueenTrade && (
+          <div className="p-4 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-700">
+            <div className="font-semibold text-amber-900 dark:text-amber-300 mb-1">🕰️ Ultimate Separation Anxiety</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerVs white={hallOfFame.slowestQueenTrade.white} black={hallOfFame.slowestQueenTrade.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.slowestQueenTrade.round} • Queens kept until move {hallOfFame.slowestQueenTrade.moves}
+            </div>
+          </div>
+        )}
+
+        {/* Edge Lord */}
+        {hallOfFame.edgeLord && (
+          <div className="p-4 bg-slate-50 dark:bg-slate-900/20 rounded-lg border border-slate-200 dark:border-slate-700">
+            <div className="font-semibold text-slate-900 dark:text-slate-300 mb-1">📐 Ultimate Professional Edger</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerName name={hallOfFame.edgeLord.color === 'White' ? hallOfFame.edgeLord.white : hallOfFame.edgeLord.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.edgeLord.round} • Made {hallOfFame.edgeLord.moves} moves on edge files (a/h)
+            </div>
+          </div>
+        )}
+
+        {/* Pawn Storm */}
+        {hallOfFame.pawnStorm && (
+          <div className="p-4 bg-cyan-50 dark:bg-cyan-900/20 rounded-lg border border-cyan-200 dark:border-cyan-700">
+            <div className="font-semibold text-cyan-900 dark:text-cyan-300 mb-1">🌪️ Ultimate Pawn Storm</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              <PlayerVs white={hallOfFame.pawnStorm.white} black={hallOfFame.pawnStorm.black} />
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              Round {hallOfFame.pawnStorm.round} • {hallOfFame.pawnStorm.count} pawn moves in the opening phase
+            </div>
+          </div>
+        )}
+
       </div>
     </StatCard>
   )

--- a/public/stats/season-2-overview.json
+++ b/public/stats/season-2-overview.json
@@ -1,6 +1,6 @@
 {
   "seasonNumber": 2,
-  "generatedAt": "2025-11-15T12:09:31.063Z",
+  "generatedAt": "2025-11-15T12:27:41.609Z",
   "roundsIncluded": [
     1,
     2,
@@ -166,6 +166,94 @@
       "white": "Christopher «Ong Passong» G.",
       "black": "Stefano «acheron» B.",
       "gameIndex": 1
+    },
+    "parkourMaster": {
+      "round": 3,
+      "knightMoves": 25,
+      "gameIndex": 7,
+      "color": "Black",
+      "white": "Nakul «Na cool» P.",
+      "black": "Max «Bird is the word» W."
+    },
+    "pawnCaptures": {
+      "round": 4,
+      "captures": 7,
+      "gameIndex": 4,
+      "color": "black",
+      "white": "Oliver «Monkey sees Pawn» K.",
+      "black": "Alejandro «Waffle» E."
+    },
+    "dadbodShuffler": {
+      "round": 3,
+      "moves": 36,
+      "gameIndex": 22,
+      "color": "White",
+      "white": "Loris «LorisNiUr» U.",
+      "black": "Giacomo «Bishop Airlines » R."
+    },
+    "darkLord": {
+      "round": 4,
+      "captures": 11,
+      "gameIndex": 4,
+      "color": "Black",
+      "white": "Oliver «Monkey sees Pawn» K.",
+      "black": "Alejandro «Waffle» E."
+    },
+    "lightLord": {
+      "round": 3,
+      "captures": 10,
+      "gameIndex": 22,
+      "color": "Black",
+      "white": "Loris «LorisNiUr» U.",
+      "black": "Giacomo «Bishop Airlines » R."
+    },
+    "squareTourist": {
+      "round": 1,
+      "squares": 25,
+      "gameIndex": 9,
+      "piece": "King",
+      "color": "Black",
+      "startSquare": "e8",
+      "white": "Mario «ChessDude» M.",
+      "black": "Dogan «Kido» P."
+    },
+    "pieceLoyalty": null,
+    "slowestCastling": {
+      "round": 4,
+      "moves": 24,
+      "gameIndex": 1,
+      "color": "white",
+      "white": "Stefano «acheron» B.",
+      "black": "Jakob «Jaquemate » ."
+    },
+    "fastestQueenTrade": {
+      "round": 2,
+      "moves": 5,
+      "gameIndex": 26,
+      "white": "Dogan «Kido» P.",
+      "black": "Valentin «valentin_benglen» C."
+    },
+    "slowestQueenTrade": {
+      "round": 3,
+      "moves": 76,
+      "gameIndex": 23,
+      "white": "Davide «AME» V.",
+      "black": "Oliver «Monkey sees Pawn» K."
+    },
+    "edgeLord": {
+      "round": 3,
+      "moves": 33,
+      "gameIndex": 23,
+      "color": "White",
+      "white": "Davide «AME» V.",
+      "black": "Oliver «Monkey sees Pawn» K."
+    },
+    "pawnStorm": {
+      "round": 1,
+      "count": 13,
+      "gameIndex": 20,
+      "white": "Janic «Clasher» S.",
+      "black": "Boris «Out of Nowhere» G."
     }
   },
   "playerStats": {

--- a/scripts/utils/overview/hall-of-fame.js
+++ b/scripts/utils/overview/hall-of-fame.js
@@ -26,7 +26,19 @@ function findHallOfFame(rounds) {
     earliestCastling: null,
     mostObscureOpening: null,
     biggestComeback: null,
-    luckyEscape: null
+    luckyEscape: null,
+    parkourMaster: null,
+    pawnCaptures: null,
+    dadbodShuffler: null,
+    darkLord: null,
+    lightLord: null,
+    squareTourist: null,
+    pieceLoyalty: null,
+    slowestCastling: null,
+    fastestQueenTrade: null,
+    slowestQueenTrade: null,
+    edgeLord: null,
+    pawnStorm: null
   }
 
   rounds.forEach(round => {
@@ -158,6 +170,102 @@ function findHallOfFame(rounds) {
       // We can't easily compare obscurity across rounds, so just take first one for now
       if (!hallOfFame.mostObscureOpening) {
         hallOfFame.mostObscureOpening = { round: roundNum, ...opening }
+      }
+    }
+
+    // Parkour master (most knight moves)
+    if (round.funStats?.parkourMaster) {
+      const parkour = round.funStats.parkourMaster
+      if (!hallOfFame.parkourMaster || parkour.knightMoves > hallOfFame.parkourMaster.knightMoves) {
+        hallOfFame.parkourMaster = { round: roundNum, ...parkour }
+      }
+    }
+
+    // Pawn captures (most captures by pawns)
+    if (round.funStats?.pawnCaptures) {
+      const pawnCaptures = round.funStats.pawnCaptures
+      if (!hallOfFame.pawnCaptures || pawnCaptures.captures > hallOfFame.pawnCaptures.captures) {
+        hallOfFame.pawnCaptures = { round: roundNum, ...pawnCaptures }
+      }
+    }
+
+    // Dadbod shuffler (most king moves)
+    if (round.funStats?.dadbodShuffler) {
+      const dadbod = round.funStats.dadbodShuffler
+      if (!hallOfFame.dadbodShuffler || dadbod.moves > hallOfFame.dadbodShuffler.moves) {
+        hallOfFame.dadbodShuffler = { round: roundNum, ...dadbod }
+      }
+    }
+
+    // Dark lord (most dark square captures)
+    if (round.funStats?.darkLord) {
+      const darkLord = round.funStats.darkLord
+      if (!hallOfFame.darkLord || darkLord.captures > hallOfFame.darkLord.captures) {
+        hallOfFame.darkLord = { round: roundNum, ...darkLord }
+      }
+    }
+
+    // Light lord (most light square captures)
+    if (round.funStats?.lightLord) {
+      const lightLord = round.funStats.lightLord
+      if (!hallOfFame.lightLord || lightLord.captures > hallOfFame.lightLord.captures) {
+        hallOfFame.lightLord = { round: roundNum, ...lightLord }
+      }
+    }
+
+    // Square tourist (most squares visited)
+    if (round.funStats?.squareTourist) {
+      const tourist = round.funStats.squareTourist
+      if (!hallOfFame.squareTourist || tourist.squares > hallOfFame.squareTourist.squares) {
+        hallOfFame.squareTourist = { round: roundNum, ...tourist }
+      }
+    }
+
+    // Piece loyalty (longest time on one square)
+    if (round.funStats?.pieceLoyalty) {
+      const loyalty = round.funStats.pieceLoyalty
+      if (!hallOfFame.pieceLoyalty || loyalty.moves > hallOfFame.pieceLoyalty.moves) {
+        hallOfFame.pieceLoyalty = { round: roundNum, ...loyalty }
+      }
+    }
+
+    // Slowest castling
+    if (round.funStats?.slowestCastling) {
+      const slowCastle = round.funStats.slowestCastling
+      if (!hallOfFame.slowestCastling || slowCastle.moves > hallOfFame.slowestCastling.moves) {
+        hallOfFame.slowestCastling = { round: roundNum, ...slowCastle }
+      }
+    }
+
+    // Fastest queen trade
+    if (round.funStats?.fastestQueenTrade) {
+      const fastQueen = round.funStats.fastestQueenTrade
+      if (!hallOfFame.fastestQueenTrade || fastQueen.moves < hallOfFame.fastestQueenTrade.moves) {
+        hallOfFame.fastestQueenTrade = { round: roundNum, ...fastQueen }
+      }
+    }
+
+    // Slowest queen trade
+    if (round.funStats?.slowestQueenTrade) {
+      const slowQueen = round.funStats.slowestQueenTrade
+      if (!hallOfFame.slowestQueenTrade || slowQueen.moves > hallOfFame.slowestQueenTrade.moves) {
+        hallOfFame.slowestQueenTrade = { round: roundNum, ...slowQueen }
+      }
+    }
+
+    // Edge lord (most edge file moves)
+    if (round.funStats?.edgeLord) {
+      const edgeLord = round.funStats.edgeLord
+      if (!hallOfFame.edgeLord || edgeLord.moves > hallOfFame.edgeLord.moves) {
+        hallOfFame.edgeLord = { round: roundNum, ...edgeLord }
+      }
+    }
+
+    // Pawn storm (most pawn moves in opening)
+    if (round.funStats?.pawnStorm) {
+      const pawnStorm = round.funStats.pawnStorm
+      if (!hallOfFame.pawnStorm || pawnStorm.count > hallOfFame.pawnStorm.count) {
+        hallOfFame.pawnStorm = { round: roundNum, ...pawnStorm }
       }
     }
   })


### PR DESCRIPTION
Previously, awards like parkourMaster and pawnCaptures appeared in round
stats but were not extracted into the season overview Hall of Fame section.
This caused them to show raw field names instead of display names.

Changes:
- Add extraction logic for 10 missing awards in hall-of-fame.js:
  * parkourMaster (most knight moves)
  * pawnCaptures (most pawn captures)
  * dadbodShuffler (most king moves)
  * darkLord (most dark square captures)
  * lightLord (most light square captures)
  * squareTourist (most squares visited)
  * pieceLoyalty (longest time on one square)
  * slowestCastling (latest castling)
  * fastestQueenTrade/slowestQueenTrade
  * edgeLord (most edge file moves)
  * pawnStorm (most pawn moves in opening)

- Add UI sections for all new awards in hall-of-fame-section.tsx
- Define TypeScript types for new award superlatives
- Regenerate season 2 overview with complete Hall of Fame (26 entries)